### PR TITLE
Fixes but with defaults and using the same option

### DIFF
--- a/packages/kirki-framework/data-option/src/Option.php
+++ b/packages/kirki-framework/data-option/src/Option.php
@@ -89,7 +89,7 @@ class Option {
 				 * We need to change the value accordingly depending on whether
 				 * this is the last item in the loop or not.
 				 */
-				$value = ( isset( $parts[ $key + 1 ] ) ) ? [] : '';
+				$value = ( isset( $parts[ $key + 1 ] ) ) ? [] : $default;
 			}
 		}
 


### PR DESCRIPTION
Fixes my part of https://github.com/kirki-framework/kirki/issues/2466

A TL;DR quick test to see the bug is to create 2 fields that save to the same option. Make sure a default is set when registering both. Then only update one of the fields. The updated field works but the default does not work for the field that doesn't have a value in the DB yet.