### PR TITLE
Create Zip With The Build Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ build/logs
 ###################
 .phpcs.xml
 phpcs.xml
+*.zip

--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,8 @@ composer install --no-dev -n
 
 echo "Removing un-necessary files inside individual packages ..."
 
+wp dist-archive . ../../
+
 # Would you like to remove the CSS source files?
 # If so, un-comment the following lines.
 # rm -rf kirki-packages/**/src/*.scss


### PR DESCRIPTION
**wp dist-archive** command requires WP CLI and `wp-cli/dist-archive-command` package
Checkout details: [https://developer.wordpress.org/cli/commands/dist-archive/](url)