### PR TITLE
Refactor: Update script dependencies for color-palette control

### DIFF
--- a/customizer/packages/controls/palette/src/Control/Palette.php
+++ b/customizer/packages/controls/palette/src/Control/Palette.php
@@ -59,7 +59,7 @@ class Palette extends Radio {
 		wp_enqueue_style( 'kirki-control-palette', URL::get_from_path( dirname( dirname( __DIR__ ) ) . '/dist/control.css' ), [], self::$control_ver );
 
 		// Enqueue the script.
-		wp_enqueue_script( 'kirki-control-palette', URL::get_from_path( dirname( dirname( __DIR__ ) ) . '/dist/control.js' ), [ 'customize-base', 'kirki-dynamic-control' ], self::$control_ver, false );
+		wp_enqueue_script( 'kirki-control-palette', URL::get_from_path( dirname( dirname( __DIR__ ) ) . '/dist/control.js' ), [ 'customize-base' ], self::$control_ver, false );
 
 	}
 


### PR DESCRIPTION
- Removed 'kirki-dynamic-control' from the script dependencies of the palette control to streamline loading and improve compatibility.