### PR TITLE
Fix: update control directory

### DIFF
--- a/customizer/packages/autoload.php
+++ b/customizer/packages/autoload.php
@@ -23,7 +23,7 @@ $packages = array(
 	'tabs'             => 'Tabs',
 );
 
-$base_dir = __DIR__ . '/';
+$base_dir = __DIR__ . '/controls/';
 
 $psr4_map = array(
 	'Kirki\\Control\\' => array(),

--- a/customizer/packages/compatibility/src/Pro_Namespace_Compatibility.php
+++ b/customizer/packages/compatibility/src/Pro_Namespace_Compatibility.php
@@ -60,7 +60,7 @@ spl_autoload_register(
 
 		// Check in Field and Control directories.
 		$base_dir = dirname( dirname( __DIR__ ) ) . '/';
-		$packages = array( 'control/margin-padding', 'control/headline-divider', 'control/input-slider', 'control/responsive', 'control/tabs' );
+		$packages = array( 'controls/margin-padding', 'controls/headline-divider', 'controls/input-slider', 'controls/responsive', 'controls/tabs' );
 
 		foreach ( $packages as $package ) {
 			$file_name = basename( $relative_path );

--- a/customizer/packages/index.php
+++ b/customizer/packages/index.php
@@ -67,7 +67,7 @@ if ( ! function_exists( 'kirki_load_controls' ) ) {
 		}
 
 		$plugin_file = defined( 'KIRKI_PLUGIN_FILE' ) ? KIRKI_PLUGIN_FILE : __FILE__;
-		define( 'KIRKI_CONTROLS_VERSION', defined( 'KIRKI_VERSION' ) ? KIRKI_VERSION : '0' );
+		define( 'KIRKI_CONTROLS_VERSION', KIRKI_VERSION );
 		define( 'KIRKI_CONTROLS_PLUGIN_FILE', $plugin_file );
 
 		kirki_init_controls();

--- a/customizer/packages/index.php
+++ b/customizer/packages/index.php
@@ -21,11 +21,11 @@ if ( ! function_exists( 'kirki_init_controls' ) ) {
 		}
 
 		$packages = array(
-			__DIR__ . '/control/headline-divider',
-			__DIR__ . '/control/input-slider',
-			__DIR__ . '/control/margin-padding',
-			__DIR__ . '/control/responsive',
-			__DIR__ . '/control/tabs',
+			__DIR__ . '/controls/headline-divider',
+			__DIR__ . '/controls/input-slider',
+			__DIR__ . '/controls/margin-padding',
+			__DIR__ . '/controls/responsive',
+			__DIR__ . '/controls/tabs',
 		);
 
 		foreach ( $packages as $package ) {
@@ -70,10 +70,11 @@ if ( ! function_exists( 'kirki_load_controls' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_data = get_plugin_data( __FILE__ );
+		$plugin_file = defined( 'KIRKI_PLUGIN_FILE' ) ? KIRKI_PLUGIN_FILE : __FILE__;
+		$plugin_data = get_plugin_data( $plugin_file, false );
 
-		define( 'KIRKI_CONTROLS_VERSION', $plugin_data['Version'] );
-		define( 'KIRKI_CONTROLS_PLUGIN_FILE', __FILE__ );
+		define( 'KIRKI_CONTROLS_VERSION', ! empty( $plugin_data['Version'] ) ? $plugin_data['Version'] : ( defined( 'KIRKI_VERSION' ) ? KIRKI_VERSION : '0' ) );
+		define( 'KIRKI_CONTROLS_PLUGIN_FILE', $plugin_file );
 
 		kirki_init_controls();
 

--- a/customizer/packages/index.php
+++ b/customizer/packages/index.php
@@ -66,14 +66,8 @@ if ( ! function_exists( 'kirki_load_controls' ) ) {
 			return;
 		}
 
-		if ( ! function_exists( 'get_plugin_data' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
 		$plugin_file = defined( 'KIRKI_PLUGIN_FILE' ) ? KIRKI_PLUGIN_FILE : __FILE__;
-		$plugin_data = get_plugin_data( $plugin_file, false );
-
-		define( 'KIRKI_CONTROLS_VERSION', ! empty( $plugin_data['Version'] ) ? $plugin_data['Version'] : ( defined( 'KIRKI_VERSION' ) ? KIRKI_VERSION : '0' ) );
+		define( 'KIRKI_CONTROLS_VERSION', defined( 'KIRKI_VERSION' ) ? KIRKI_VERSION : '0' );
 		define( 'KIRKI_CONTROLS_PLUGIN_FILE', $plugin_file );
 
 		kirki_init_controls();


### PR DESCRIPTION
update control directory files

- Changed the base directory for controls from 'control/' to 'controls/' in autoload.php.
- Updated package paths in index.php and Pro_Namespace_Compatibility.php to reflect the new 'controls/' directory structure.